### PR TITLE
Add Prem App as option to run LLM locally (or your GPU server/cluster)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,7 +171,11 @@ Default: `https://api.openai.com/v1`
 
 A server following OpenAI's Chat Completion API.
 
-Many local proxies exist that implement this API in front of locally running LLMs like Llama 2. [LM Studio](https://lmstudio.ai/) is a good option.
+Many local proxies exist that implement this API in front of locally running LLMs like Llama 2. 
+
+Available options:
+- [Prem App](https://premai.io/)
+- [LM Studio](https://lmstudio.ai/)
 
 ```shell
 HUMANSCRIPT_API="http://localhost:1234/v1"


### PR DESCRIPTION
Love the project and the interest to allow users to use self-hosted LLMs besides OpenAI. Prem exposes many Chat models and uses the OpenAI API as well.