### PR TITLE
Formating in Readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,8 +135,7 @@ echo 'HUMANSCRIPT_API_KEY="<your-openai-api-key>"' >> ~/.humanscript/config
 Now you can create a humanscript and make it executable.
 
 ```shell
-echo '#!/usr/bin/env humanscript
-print an ascii art human' > asciiman
+echo '#!/usr/bin/env humanscript print an ascii art human' > asciiman
 chmod +x asciiman
 ```
 


### PR DESCRIPTION
One of the shell commands was broken up into lines, but appears to be one command. I apologize if I am wrong. 